### PR TITLE
chore: update dependency reference

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -1,7 +1,7 @@
 package maryhelp
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/ansel1/merry"
 )
 


### PR DESCRIPTION
We should be using the lowercase name, otherwise `go mod` will not work.